### PR TITLE
Defensive input validation v console commands + AMQPTable narrowing

### DIFF
--- a/src/Console/ConsumerCommand.php
+++ b/src/Console/ConsumerCommand.php
@@ -9,6 +9,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use UnexpectedValueException;
 
 #[AsCommand(name: 'rabbitmq:consumer', description: 'Run a RabbitMQ consumer')]
 final class ConsumerCommand extends Command
@@ -28,11 +29,17 @@ final class ConsumerCommand extends Command
 
 	protected function execute(InputInterface $input, OutputInterface $output): int
 	{
-		$consumerName = (string) $input->getArgument('consumerName');
+		$consumerName = $input->getArgument('consumerName');
+		if (!is_string($consumerName)) {
+			throw new UnexpectedValueException('Argument [consumerName] must be a string');
+		}
 		$this->validateConsumer($consumerName);
 
 		$secondsToLive = $input->getArgument('secondsToLive');
 		if ($secondsToLive !== null) {
+			if (!is_numeric($secondsToLive)) {
+				throw new UnexpectedValueException('Argument [secondsToLive] must be numeric');
+			}
 			$secondsToLive = (int) $secondsToLive;
 			if ($secondsToLive <= 0) {
 				throw new InvalidArgumentException('Parameter [secondsToLive] has to be greater than 0');

--- a/src/Console/StaticConsumerCommand.php
+++ b/src/Console/StaticConsumerCommand.php
@@ -9,6 +9,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use UnexpectedValueException;
 
 #[AsCommand(name: 'rabbitmq:staticConsumer', description: 'Run a RabbitMQ consumer but consume just particular amount of messages')]
 final class StaticConsumerCommand extends Command
@@ -28,10 +29,17 @@ final class StaticConsumerCommand extends Command
 
 	protected function execute(InputInterface $input, OutputInterface $output): int
 	{
-		$consumerName = (string) $input->getArgument('consumerName');
+		$consumerName = $input->getArgument('consumerName');
+		if (!is_string($consumerName)) {
+			throw new UnexpectedValueException('Argument [consumerName] must be a string');
+		}
 		$this->validateConsumer($consumerName);
 
-		$amountOfMessages = (int) $input->getArgument('amountOfMessages');
+		$amountOfMessages = $input->getArgument('amountOfMessages');
+		if (!is_numeric($amountOfMessages)) {
+			throw new UnexpectedValueException('Argument [amountOfMessages] must be numeric');
+		}
+		$amountOfMessages = (int) $amountOfMessages;
 		if ($amountOfMessages <= 0) {
 			throw new InvalidArgumentException('Parameter [amountOfMessages] has to be greater than 0');
 		}

--- a/src/Consumer/Consumer.php
+++ b/src/Consumer/Consumer.php
@@ -6,6 +6,7 @@ use Haltuf\RabbitMQ\Connection\Connection;
 use InvalidArgumentException;
 use PhpAmqpLib\Exception\AMQPTimeoutException;
 use PhpAmqpLib\Message\AMQPMessage;
+use PhpAmqpLib\Wire\AMQPTable;
 
 class Consumer
 {
@@ -83,7 +84,10 @@ class Consumer
 	{
 		$headers = [];
 		if ($amqpMessage->has('application_headers')) {
-			$headers = $amqpMessage->get('application_headers')->getNativeData();
+			$appHeaders = $amqpMessage->get('application_headers');
+			if ($appHeaders instanceof AMQPTable) {
+				$headers = $appHeaders->getNativeData();
+			}
 		}
 
 		return new Message(


### PR DESCRIPTION
## Změny

Dvě drobné hardening úpravy vytažené z analýzy, jaké změny by dávaly smysl i při setrvání na phpstan level 8 (viz debata k level 9).

### 1. `ConsumerCommand` / `StaticConsumerCommand` — validace CLI vstupů

Místo tichých castů (`(string) $input->getArgument(...)`, `(int) $input->getArgument(...)`) používáme `is_string` / `is_numeric` guard + `UnexpectedValueException`. Důvod: Symfony `InputInterface::getArgument()` vrací `mixed` — runtime typ může být `null`, array, bool apod. Silent cast dává nesmyslné výsledky (`null → ''`, `array → 'Array'`, `true → '1'`) a bugy se projeví až hluboko v callbackách.

Stejný vzor má i `contributte/rabbitmq` v jejich `ConsumerCommand::execute()` — není to kvůli phpstan, je to obecně správný přístup k CLI inputu.

### 2. `Consumer::createMessage()` — `instanceof AMQPTable` narrow

Původně:
```php
if ($amqpMessage->has('application_headers')) {
    $headers = $amqpMessage->get('application_headers')->getNativeData();
}
```

Spoléhalo na to, že `has('application_headers')` implikuje, že hodnota je `AMQPTable`. Není to zaručené — teoreticky může dorazit zpráva, kde `application_headers` existuje, ale je jiného typu, a `->getNativeData()` by spadlo na `Call to a member function on non-object`. Přidávám `instanceof AMQPTable` check před voláním.

## Testy

Lokálně ověřeno v dockeru:
- `vendor/bin/phpstan analyse` — OK, no errors
- `vendor/bin/ecs check` — OK, no errors

Existující integrační testy pokrývají happy-path i `getNativeData()` průchod, takže regrese se zachytí v CI.

## Poznámka

Žádná z těchto změn není ve public API (konstruktory, metody, návratové typy zůstávají identické), takže se nedotýká kompatibility s `contributte/rabbitmq` migrací popsanou v README.