### PR TITLE
CI: bump actions/checkout@v4 → @v5 (Node.js 24)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     name: PHPStan (level 8)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: shivammathur/setup-php@v2
         with:
           php-version: '8.4'
@@ -24,7 +24,7 @@ jobs:
     name: ECS (PSR-12 + project rules)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: shivammathur/setup-php@v2
         with:
           php-version: '8.4'
@@ -52,7 +52,7 @@ jobs:
           --health-timeout 5s
           --health-retries 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}


### PR DESCRIPTION
Odstraňuje deprecation warning z CI runů — `actions/checkout@v4` běží na Node.js 20, který GitHub Actions odstraní 16. 9. 2026. `@v5` běží na Node.js 24. Diff je 3 řádky, jen verze.