### PR TITLE
README: upřesnit rozsah namespace rename v migračním návodu

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,13 @@ Ve všech souborech najdi a nahraď:
 +use Haltuf\RabbitMQ\
 ```
 
-Typicky půjde jen o consumer handlery, kde jsi importoval `IConsumer` konstanty. Ostatní místa (DI container, producer publish, atd.) jsou namespace-agnostická.
+Rename se týká **všech souborů, které importují jakoukoli třídu nebo konstantu z `Contributte\RabbitMQ\`** — typicky consumer handlery (`IConsumer` konstanty), ale i služby, presentery a event dispatchery, které mají typovaný `Client` pro publikování zpráv. V reálném Nette projektu střední velikosti jde řádově o **10–15 souborů**. Najdi všechny výskyty:
+
+```bash
+grep -rlF 'use Contributte\RabbitMQ' app/ src/ bin/
+```
+
+DI container konfigurace (`config.neon`) a runtime publish volání přes `$client->getProducer('name')->publish(...)` jsou namespace-agnostická a žádné změny nevyžadují.
 
 ### Drobné rozdíly
 


### PR DESCRIPTION
## Změny

Přepisuje v sekci _Migrace z contributte/rabbitmq_ / krok 3 (find-replace namespace) větu o rozsahu rename. Původní text tvrdil, že „typicky jen consumer handlery" — realita z migrace `cena-vykon.cz` (viz price2performance/cena-vykon#579) ukázala, že rename je potřeba **všude, kde je importovaná jakákoli třída z `Contributte\RabbitMQ\`**, řádově v **10–15 souborech** včetně služeb, presenterů a event dispatcherů, které mají typovaný `Client`, ne jen v consumer handlerech. Přidává i konkrétní `grep` příkaz pro snadné najití všech výskytů.

## Disposice bodů z #4

- **Bod 1 — `composer require haltuf/rabbitmq` selže, protože balíček není na Packagistu:** vědomě neřeším v README. Je to dočasný stav, tracking point v #1 (Initial public release — acceptance criteria zahrnují Packagist hook). Jakmile bude balíček veřejný + na Packagistu, instrukce z README bude fungovat tak, jak je napsaná. Přidávat „Beta: přidejte VCS repo..." warning, který zmizí za pár dní, je churn.
- **Bod 2 — namespace rename je větší než „jen handlery":** ✅ řeší tento PR.
- **Bod 3 — API a config jsou 1:1 s inline verzí, „seamless switch" claim platí:** pozitivní datová potvrzení z migrace, žádná akce v kódu potřeba.

Closes #4
