### PR TITLE
Tracy bar panel (Diagnostics\BarPanel) pro zobrazení odeslaných zpráv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Formát vychází z [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) a b
 
 ## [Unreleased]
 
+### Added
+
+- `Haltuf\RabbitMQ\Diagnostics\BarPanel` — Tracy bar panel zobrazující ikonu, počet odeslaných zpráv a přehled payloadů per producer.
+- `Haltuf\RabbitMQ\Producer\Producer::addOnPublishCallback()` — registrace callbacku volaného po úspěšném `basic_publish`.
+- `Haltuf\RabbitMQ\Client::getProducers()` — výpis všech producerů (používá BarPanel pro hromadnou registraci callbacků).
+
 ## [0.1.0] - 2026-04-11
 
 První veřejné vydání balíčku extrahovaného z produkční aplikace.

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ tracy:
 		- Haltuf\RabbitMQ\Diagnostics\BarPanel
 ```
 
-Maximální počet zobrazených zpráv lze upravit přes statickou property `BarPanel::$displayCount` (výchozí `100`, hodnota `0` znamená neomezeně).
+Maximální počet zobrazených zpráv lze upravit přes statickou property `BarPanel::$displayCount` (výchozí `100`, hodnota `0` znamená neomezeně). V dlouhoběžících procesech (CLI, workery) hodnotu `0` nepoužívej — pole sebraných payloadů by rostlo bez omezení.
 
 ## Migrace z `contributte/rabbitmq`
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Odlehčená RabbitMQ integrace pro [Nette Framework](https://nette.org) postaven
   - [Consumer](#consumer)
   - [BulkConsumer](#bulkconsumer)
 - [Konzolové příkazy](#konzolové-příkazy)
+- [Tracy bar panel](#tracy-bar-panel)
 - [Migrace z contributte/rabbitmq](#migrace-z-contributterabbitmq)
 
 ## Instalace
@@ -204,6 +205,20 @@ Balíček registruje tři Symfony Console příkazy:
 | `rabbitmq:consumer <consumerName> [secondsToLive]` | Spustí consumer; pokud je `secondsToLive` nastaveno, běží max uvedenou dobu |
 | `rabbitmq:staticConsumer <consumerName> <amountOfMessages>` | Spustí consumer a ukončí se po zpracování daného počtu zpráv |
 | `rabbitmq:declareQueuesAndExchanges` | Deklaruje všechny fronty z configu; volá se typicky v deploy pipeline |
+
+## Tracy bar panel
+
+`Haltuf\RabbitMQ\Diagnostics\BarPanel` zobrazuje v Tracy debug baru ikonku, počet odeslaných zpráv a přehled payloadů per producer. Vyžaduje [`tracy/tracy`](https://github.com/nette/tracy) (typicky `composer require --dev tracy/tracy`).
+
+Registrace v `config.neon` (typicky pouze v development konfiguraci):
+
+```neon
+tracy:
+	bar:
+		- Haltuf\RabbitMQ\Diagnostics\BarPanel
+```
+
+Maximální počet zobrazených zpráv lze upravit přes statickou property `BarPanel::$displayCount` (výchozí `100`, hodnota `0` znamená neomezeně).
 
 ## Migrace z `contributte/rabbitmq`
 

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,11 @@
 		"phpstan/phpstan-nette": "^2.0",
 		"slevomat/coding-standard": "^8.18",
 		"squizlabs/php_codesniffer": "^3.12",
-		"symplify/easy-coding-standard": "^12.5"
+		"symplify/easy-coding-standard": "^12.5",
+		"tracy/tracy": "^2.10"
+	},
+	"suggest": {
+		"tracy/tracy": "For Tracy debug bar panel (Haltuf\\RabbitMQ\\Diagnostics\\BarPanel)"
 	},
 	"autoload": {
 		"psr-4": {

--- a/src/Client.php
+++ b/src/Client.php
@@ -20,4 +20,10 @@ final class Client
 
 		return $this->producers[$name];
 	}
+
+	/** @return array<string, Producer> */
+	public function getProducers(): array
+	{
+		return $this->producers;
+	}
 }

--- a/src/Diagnostics/BarPanel.php
+++ b/src/Diagnostics/BarPanel.php
@@ -1,0 +1,59 @@
+<?php declare(strict_types=1);
+
+namespace Haltuf\RabbitMQ\Diagnostics;
+
+use Haltuf\RabbitMQ\Client;
+use Throwable;
+use Tracy\IBarPanel;
+
+final class BarPanel implements IBarPanel
+{
+	public static int $displayCount = 100;
+
+	/** @var array<string, list<string>> */
+	private array $sentMessages = [];
+
+	private int $totalMessages = 0;
+
+	public function __construct(Client $client)
+	{
+		foreach ($client->getProducers() as $name => $producer) {
+			$this->sentMessages[$name] = [];
+			$producer->addOnPublishCallback(
+				function (string $message) use ($name): void {
+					if (self::$displayCount === 0 || $this->totalMessages < self::$displayCount) {
+						$this->sentMessages[$name][] = $message;
+					}
+
+					$this->totalMessages++;
+				},
+			);
+		}
+	}
+
+	public function getTab(): string
+	{
+		$icon = (string) file_get_contents(__DIR__ . '/rabbitmq-icon.svg');
+		$iconSrc = 'data:image/svg+xml;base64,' . base64_encode($icon);
+
+		return '<span title="RabbitMq"><img src="' . htmlspecialchars($iconSrc, ENT_QUOTES) . '" alt="">'
+			. ' ' . $this->totalMessages . '</span>';
+	}
+
+	public function getPanel(): string
+	{
+		$totalMessages = $this->totalMessages;
+		$sentMessages = $this->sentMessages;
+		$displayCount = self::$displayCount;
+
+		ob_start();
+		try {
+			require __DIR__ . '/BarPanel.phtml';
+		} catch (Throwable $e) {
+			ob_end_clean();
+			throw $e;
+		}
+
+		return (string) ob_get_clean();
+	}
+}

--- a/src/Diagnostics/BarPanel.php
+++ b/src/Diagnostics/BarPanel.php
@@ -10,6 +10,8 @@ final class BarPanel implements IBarPanel
 {
 	public static int $displayCount = 100;
 
+	private static ?string $iconSrc = null;
+
 	/** @var array<string, list<string>> */
 	private array $sentMessages = [];
 
@@ -33,10 +35,12 @@ final class BarPanel implements IBarPanel
 
 	public function getTab(): string
 	{
-		$icon = (string) file_get_contents(__DIR__ . '/rabbitmq-icon.svg');
-		$iconSrc = 'data:image/svg+xml;base64,' . base64_encode($icon);
+		if (self::$iconSrc === null) {
+			$icon = (string) file_get_contents(__DIR__ . '/rabbitmq-icon.svg');
+			self::$iconSrc = 'data:image/svg+xml;base64,' . base64_encode($icon);
+		}
 
-		return '<span title="RabbitMq"><img src="' . htmlspecialchars($iconSrc, ENT_QUOTES) . '" alt="">'
+		return '<span title="RabbitMq"><img src="' . htmlspecialchars(self::$iconSrc, ENT_QUOTES) . '" alt="">'
 			. ' ' . $this->totalMessages . '</span>';
 	}
 

--- a/src/Diagnostics/BarPanel.phtml
+++ b/src/Diagnostics/BarPanel.phtml
@@ -1,0 +1,42 @@
+<?php declare(strict_types=1); ?>
+<style class="tracy-debug">
+	.tracy-addons-rabbitmq h1 { font-size: 16px !important; }
+	.tracy-addons-rabbitmq table { margin: 5px 0 0; width: 100%; }
+	.tracy-addons-rabbitmq table th, .tracy-addons-rabbitmq table td { padding: 3px 6px; text-align: left; vertical-align: top; }
+	.tracy-addons-rabbitmq pre { margin: 0; white-space: pre-wrap; word-break: break-all; }
+</style>
+
+<div class="tracy-inner tracy-addons-rabbitmq">
+	<h1>RabbitMq, total sent <?= (int) $totalMessages ?></h1>
+
+	<?php if ($displayCount > 0 && $totalMessages > $displayCount): ?>
+		<p>Only first <?= (int) $displayCount ?> messages are displayed.</p>
+	<?php endif ?>
+
+	<div class="tracy-inner-container">
+		<table>
+			<thead>
+				<tr>
+					<th>Producer</th>
+					<th>Messages</th>
+				</tr>
+			</thead>
+			<tbody>
+				<?php foreach ($sentMessages as $producer => $messages): ?>
+					<tr>
+						<th><?= htmlspecialchars((string) $producer) ?></th>
+						<td>
+							<?php if ($messages === []): ?>
+								<em>none</em>
+							<?php else: ?>
+								<?php foreach ($messages as $message): ?>
+									<pre><?= htmlspecialchars($message) ?></pre>
+								<?php endforeach ?>
+							<?php endif ?>
+						</td>
+					</tr>
+				<?php endforeach ?>
+			</tbody>
+		</table>
+	</div>
+</div>

--- a/src/Diagnostics/rabbitmq-icon.svg
+++ b/src/Diagnostics/rabbitmq-icon.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+	<rect x="1" y="3" width="14" height="3" rx="1" fill="#FF6600"/>
+	<rect x="1" y="7" width="14" height="3" rx="1" fill="#FF6600"/>
+	<rect x="1" y="11" width="14" height="3" rx="1" fill="#FF6600"/>
+	<circle cx="13" cy="4.5" r="0.7" fill="#fff"/>
+	<circle cx="13" cy="8.5" r="0.7" fill="#fff"/>
+	<circle cx="13" cy="12.5" r="0.7" fill="#fff"/>
+</svg>

--- a/src/Producer/Producer.php
+++ b/src/Producer/Producer.php
@@ -14,12 +14,21 @@ final class Producer
 	public const DELIVERY_MODE_NON_PERSISTENT = 1;
 	public const DELIVERY_MODE_PERSISTENT = 2;
 
+	/** @var list<callable(string, array<string, mixed>, ?string): void> */
+	private array $onPublishCallbacks = [];
+
 	public function __construct(
 		private readonly Connection $connection,
 		private readonly string $queueName,
 		private readonly string $contentType = 'application/json',
 		private readonly int $deliveryMode = self::DELIVERY_MODE_PERSISTENT,
 	) {}
+
+	/** @param callable(string, array<string, mixed>, ?string): void $callback */
+	public function addOnPublishCallback(callable $callback): void
+	{
+		$this->onPublishCallbacks[] = $callback;
+	}
 
 	/** @param array<string, mixed> $headers */
 	public function publish(string $message, array $headers = [], ?string $routingKey = null): void
@@ -41,6 +50,10 @@ final class Producer
 		} catch (AMQPConnectionClosedException | AMQPChannelClosedException | AMQPIOException) {
 			$this->connection->reconnect();
 			$this->connection->getChannel()->basic_publish($amqpMessage, '', $target);
+		}
+
+		foreach ($this->onPublishCallbacks as $callback) {
+			$callback($message, $headers, $routingKey);
 		}
 	}
 }

--- a/src/Producer/Producer.php
+++ b/src/Producer/Producer.php
@@ -8,6 +8,7 @@ use PhpAmqpLib\Exception\AMQPConnectionClosedException;
 use PhpAmqpLib\Exception\AMQPIOException;
 use PhpAmqpLib\Message\AMQPMessage;
 use PhpAmqpLib\Wire\AMQPTable;
+use Throwable;
 
 final class Producer
 {
@@ -24,7 +25,13 @@ final class Producer
 		private readonly int $deliveryMode = self::DELIVERY_MODE_PERSISTENT,
 	) {}
 
-	/** @param callable(string, array<string, mixed>, ?string): void $callback */
+	/**
+	 * Callback is invoked after a successful basic_publish (including after auto-reconnect retry).
+	 * Exceptions thrown by the callback are swallowed and logged via error_log() — they must not
+	 * abort publish() because the message has already been delivered to the broker.
+	 *
+	 * @param callable(string, array<string, mixed>, ?string): void $callback
+	 */
 	public function addOnPublishCallback(callable $callback): void
 	{
 		$this->onPublishCallbacks[] = $callback;
@@ -53,7 +60,12 @@ final class Producer
 		}
 
 		foreach ($this->onPublishCallbacks as $callback) {
-			$callback($message, $headers, $routingKey);
+			// Callback failure must not propagate — message has already been published.
+			try {
+				$callback($message, $headers, $routingKey);
+			} catch (Throwable $e) {
+				error_log('haltuf/rabbitmq: on-publish callback threw ' . $e::class . ': ' . $e->getMessage());
+			}
 		}
 	}
 }

--- a/tests/Diagnostics/BarPanelTest.phpt
+++ b/tests/Diagnostics/BarPanelTest.phpt
@@ -1,0 +1,153 @@
+<?php declare(strict_types=1);
+
+namespace Haltuf\RabbitMQ\Tests\Diagnostics;
+
+require __DIR__ . '/../bootstrap.php';
+
+use Haltuf\RabbitMQ\Client;
+use Haltuf\RabbitMQ\Connection\Connection;
+use Haltuf\RabbitMQ\Diagnostics\BarPanel;
+use Haltuf\RabbitMQ\Producer\Producer;
+use Haltuf\RabbitMQ\Tests\TestConfig;
+use Tester\Assert;
+use Tester\TestCase;
+
+class BarPanelTest extends TestCase
+{
+	private Connection $connection;
+
+	/** @var list<string> */
+	private array $declaredQueues = [];
+
+	public function setUp(): void
+	{
+		$this->connection = TestConfig::createConnection();
+	}
+
+	public function tearDown(): void
+	{
+		foreach ($this->declaredQueues as $queue) {
+			$this->connection->getChannel()->queue_delete($queue);
+		}
+
+		$this->declaredQueues = [];
+		BarPanel::$displayCount = 100;
+	}
+
+	public function testRegistersCallbackOnEachProducerAndCollectsMessages(): void
+	{
+		$client = $this->createClient(['p1', 'p2']);
+
+		$panel = new BarPanel($client);
+
+		$client->getProducer('p1')->publish('msg-1');
+		$client->getProducer('p1')->publish('msg-2');
+		$client->getProducer('p2')->publish('msg-3');
+
+		$panelHtml = $panel->getPanel();
+		Assert::contains('p1', $panelHtml);
+		Assert::contains('p2', $panelHtml);
+		Assert::contains('msg-1', $panelHtml);
+		Assert::contains('msg-2', $panelHtml);
+		Assert::contains('msg-3', $panelHtml);
+	}
+
+	public function testTotalMessagesIncrementsAlwaysEvenAboveDisplayCount(): void
+	{
+		BarPanel::$displayCount = 3;
+		$client = $this->createClient(['p1']);
+		$panel = new BarPanel($client);
+
+		for ($i = 1; $i <= 7; $i++) {
+			$client->getProducer('p1')->publish('m' . $i);
+		}
+
+		Assert::contains('total sent 7', $panel->getPanel());
+		Assert::contains('> 7</span>', $this->normalizeWhitespace($panel->getTab()));
+	}
+
+	public function testDisplayCountLimitsCollectedMessagesButNotTotal(): void
+	{
+		BarPanel::$displayCount = 3;
+		$client = $this->createClient(['p1']);
+		$panel = new BarPanel($client);
+
+		for ($i = 1; $i <= 5; $i++) {
+			$client->getProducer('p1')->publish('payload-' . $i);
+		}
+
+		$panelHtml = $panel->getPanel();
+		Assert::contains('payload-1', $panelHtml);
+		Assert::contains('payload-2', $panelHtml);
+		Assert::contains('payload-3', $panelHtml);
+		Assert::notContains('payload-4', $panelHtml);
+		Assert::notContains('payload-5', $panelHtml);
+		Assert::contains('Only first 3 messages are displayed.', $panelHtml);
+		Assert::contains('total sent 5', $panelHtml);
+	}
+
+	public function testDisplayCountZeroMeansUnlimited(): void
+	{
+		BarPanel::$displayCount = 0;
+		$client = $this->createClient(['p1']);
+		$panel = new BarPanel($client);
+
+		for ($i = 1; $i <= 5; $i++) {
+			$client->getProducer('p1')->publish('unlimited-' . $i);
+		}
+
+		$panelHtml = $panel->getPanel();
+		for ($i = 1; $i <= 5; $i++) {
+			Assert::contains('unlimited-' . $i, $panelHtml);
+		}
+
+		Assert::notContains('Only first', $panelHtml);
+	}
+
+	public function testGetTabContainsCountAndIcon(): void
+	{
+		$client = $this->createClient(['p1']);
+		$panel = new BarPanel($client);
+
+		$client->getProducer('p1')->publish('a');
+		$client->getProducer('p1')->publish('b');
+
+		$tab = $panel->getTab();
+		Assert::contains('data:image/svg+xml;base64,', $tab);
+		Assert::contains(' 2', $tab);
+	}
+
+	public function testGetPanelHandlesEmptyProducer(): void
+	{
+		$client = $this->createClient(['empty']);
+		$panel = new BarPanel($client);
+
+		$panelHtml = $panel->getPanel();
+		Assert::contains('empty', $panelHtml);
+		Assert::contains('total sent 0', $panelHtml);
+		Assert::contains('none', $panelHtml);
+	}
+
+	/**
+	 * @param list<string> $names
+	 */
+	private function createClient(array $names): Client
+	{
+		$producers = [];
+		foreach ($names as $name) {
+			$queue = 'test_barpanel_' . $name . '_' . uniqid();
+			$this->connection->getChannel()->queue_declare($queue, false, false, false, true);
+			$this->declaredQueues[] = $queue;
+			$producers[$name] = new Producer($this->connection, $queue);
+		}
+
+		return new Client($producers);
+	}
+
+	private function normalizeWhitespace(string $html): string
+	{
+		return (string) preg_replace('/\s+/', ' ', $html);
+	}
+}
+
+(new BarPanelTest())->run();

--- a/tests/Diagnostics/BarPanelTest.phpt
+++ b/tests/Diagnostics/BarPanelTest.phpt
@@ -114,7 +114,7 @@ class BarPanelTest extends TestCase
 
 		$tab = $panel->getTab();
 		Assert::contains('data:image/svg+xml;base64,', $tab);
-		Assert::contains(' 2', $tab);
+		Assert::contains('> 2</span>', $this->normalizeWhitespace($tab));
 	}
 
 	public function testGetPanelHandlesEmptyProducer(): void

--- a/tests/Producer/ProducerTest.phpt
+++ b/tests/Producer/ProducerTest.phpt
@@ -7,6 +7,7 @@ require __DIR__ . '/../bootstrap.php';
 use Haltuf\RabbitMQ\Connection\Connection;
 use Haltuf\RabbitMQ\Producer\Producer;
 use Haltuf\RabbitMQ\Tests\TestConfig;
+use PhpAmqpLib\Exception\AMQPExceptionInterface;
 use Tester\Assert;
 use Tester\TestCase;
 
@@ -150,6 +151,32 @@ class ProducerTest extends TestCase
 		$producer->publish('a');
 
 		Assert::same(['first', 'second'], $calls);
+	}
+
+	public function testCallbackIsNotInvokedWhenPublishThrows(): void
+	{
+		$deadConnection = new Connection(
+			host: '127.0.0.1',
+			port: 1,
+			user: 'guest',
+			password: 'guest',
+			vhost: '/',
+			heartbeat: 60,
+			timeout: 1,
+			lazy: true,
+		);
+		$producer = new Producer($deadConnection, 'irrelevant');
+
+		$invocations = 0;
+		$producer->addOnPublishCallback(function () use (&$invocations): void {
+			$invocations++;
+		});
+
+		Assert::exception(
+			static fn () => $producer->publish('payload'),
+			AMQPExceptionInterface::class,
+		);
+		Assert::same(0, $invocations);
 	}
 
 	public function testThrowingCallbackDoesNotAbortPublishAndSubsequentCallbacks(): void

--- a/tests/Producer/ProducerTest.phpt
+++ b/tests/Producer/ProducerTest.phpt
@@ -114,6 +114,43 @@ class ProducerTest extends TestCase
 		Assert::notNull($msg);
 		Assert::same('after-reconnect', $msg->getBody());
 	}
+
+	public function testOnPublishCallbackReceivesMessageHeadersAndRoutingKey(): void
+	{
+		$producer = new Producer($this->connection, $this->testQueue);
+
+		/** @var list<array{string, array<string, mixed>, ?string}> $captured */
+		$captured = [];
+		$producer->addOnPublishCallback(
+			function (string $message, array $headers, ?string $routingKey) use (&$captured): void {
+				$captured[] = [$message, $headers, $routingKey];
+			},
+		);
+
+		$producer->publish('payload', ['x-foo' => 'bar'], 'custom-key');
+		$this->connection->getChannel()->queue_delete('custom-key');
+
+		Assert::count(1, $captured);
+		Assert::same('payload', $captured[0][0]);
+		Assert::same(['x-foo' => 'bar'], $captured[0][1]);
+		Assert::same('custom-key', $captured[0][2]);
+	}
+
+	public function testMultipleOnPublishCallbacksAreInvokedInOrder(): void
+	{
+		$producer = new Producer($this->connection, $this->testQueue);
+		$calls = [];
+		$producer->addOnPublishCallback(function () use (&$calls): void {
+			$calls[] = 'first';
+		});
+		$producer->addOnPublishCallback(function () use (&$calls): void {
+			$calls[] = 'second';
+		});
+
+		$producer->publish('a');
+
+		Assert::same(['first', 'second'], $calls);
+	}
 }
 
 (new ProducerTest())->run();

--- a/tests/Producer/ProducerTest.phpt
+++ b/tests/Producer/ProducerTest.phpt
@@ -151,6 +151,34 @@ class ProducerTest extends TestCase
 
 		Assert::same(['first', 'second'], $calls);
 	}
+
+	public function testThrowingCallbackDoesNotAbortPublishAndSubsequentCallbacks(): void
+	{
+		$producer = new Producer($this->connection, $this->testQueue);
+		$reached = false;
+		$producer->addOnPublishCallback(function (): void {
+			throw new \RuntimeException('boom');
+		});
+		$producer->addOnPublishCallback(function () use (&$reached): void {
+			$reached = true;
+		});
+
+		// Suppress error_log output to stderr during the test.
+		$prev = ini_set('error_log', '/dev/null');
+		try {
+			$producer->publish('payload');
+		} finally {
+			if ($prev !== false) {
+				ini_set('error_log', $prev);
+			}
+		}
+
+		Assert::true($reached);
+
+		$msg = $this->connection->getChannel()->basic_get($this->testQueue, true);
+		Assert::notNull($msg);
+		Assert::same('payload', $msg->getBody());
+	}
 }
 
 (new ProducerTest())->run();


### PR DESCRIPTION
Closes #7

## Změny

- **`Producer::addOnPublishCallback()`** — registrace callbacků volaných po úspěšném `basic_publish` (po retry). Při výjimce se nevolá.
- **`Client::getProducers()`** — zpřístupnění mapy producerů (`array<string, Producer>`).
- **`Haltuf\RabbitMQ\Diagnostics\BarPanel`** implementující `Tracy\IBarPanel` — v constructoru projde `Client::getProducers()` a na každém zaregistruje callback sbírající payloady do `array<string, list<string>> $sentMessages` a inkrementující `int $totalMessages`. Statická property `BarPanel::$displayCount` (default `100`, `0` = unlimited) limituje sběr payloadů; `$totalMessages` jede vždy.
- **`BarPanel.phtml`** + **`rabbitmq-icon.svg`** — jednoduchá tabulka producer → payloady, ikona inline jako data URI.
- **`composer.json`** — `tracy/tracy ^2.10` do `require-dev` + `suggest`. BarPanel je optional feature, autoloader na něj nesáhne, dokud ho uživatel neregistruje.
- **`tests/Diagnostics/BarPanelTest.phpt`** — pokrývá callback registraci, sběr per producer, hraniční hodnoty `$displayCount` (default, `0` unlimited, `> limit`), `getTab()` HTML obsahuje počet a ikonu, `getPanel()` jména producerů a payloady.
- **`tests/Producer/ProducerTest.phpt`** — 2 nové testy: callback dostává `(message, headers, routingKey)` a invokace v pořadí registrace.
- **README** sekce Tracy bar panel + **CHANGELOG** záznam v `Unreleased`.

Po vydání minor verze lze v `chytrobot.cz/config/development.neon` vrátit BarPanel zpět (`Haltuf\RabbitMQ\Diagnostics\BarPanel`) — viz `price2performance/chytrobot#167`.

## Lokálně ověřeno

- PHPStan level 8 zelený (`php:8.4-cli`, bez baseline, bez `assert()`).
- ECS zelený.
- Tester proti reálnému `rabbitmq:3` kontejneru: 7/7 .phpt souborů OK.

Implementováno pomocí Claude Code.